### PR TITLE
0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "fracture"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "ashpd",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "lamco-wgpu"
 version = "0.1.0"
-source = "git+https://github.com/parker-andrew-forks/wgpu-bridge.git?rev=72e0dfdec4aa75adfcd4383be4dcffafa26eaff8#72e0dfdec4aa75adfcd4383be4dcffafa26eaff8"
+source = "git+https://github.com/parker-andrew-forks/wgpu-bridge.git?rev=6159eaf26e9a1a0d78f45d843f90d361706c9620#6159eaf26e9a1a0d78f45d843f90d361706c9620"
 dependencies = [
  "ash",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "lamco-wgpu"
 version = "0.1.0"
-source = "git+https://github.com/parker-andrew-forks/wgpu-bridge.git?rev=6159eaf26e9a1a0d78f45d843f90d361706c9620#6159eaf26e9a1a0d78f45d843f90d361706c9620"
+source = "git+https://github.com/parker-andrew-forks/wgpu-bridge.git?rev=72e0dfdec4aa75adfcd4383be4dcffafa26eaff8#72e0dfdec4aa75adfcd4383be4dcffafa26eaff8"
 dependencies = [
  "ash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fracture"
 rust-version = "1.92"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = {version="1.41.1", features=["rt"]}
 wgpu = {version="28.0.0", features=["naga-ir", "serde"]}
 winit = "0.30.13"
 wgsl-formatter = {git="https://github.com/parker-andrew-forks/wgsl-analyzer.git", rev="3d5590767e816bdf2d6f5c7c9b304632006a1631"}
-lamco-wgpu = { git = "https://github.com/parker-andrew-forks/wgpu-bridge.git", rev="6159eaf26e9a1a0d78f45d843f90d361706c9620"}
+lamco-wgpu = { git = "https://github.com/parker-andrew-forks/wgpu-bridge.git", rev="72e0dfdec4aa75adfcd4383be4dcffafa26eaff8"}
 open = "5.3.2"
 rand = {version="0.9"}
 detect-desktop-environment = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = {version="1.41.1", features=["rt"]}
 wgpu = {version="28.0.0", features=["naga-ir", "serde"]}
 winit = "0.30.13"
 wgsl-formatter = {git="https://github.com/parker-andrew-forks/wgsl-analyzer.git", rev="3d5590767e816bdf2d6f5c7c9b304632006a1631"}
-lamco-wgpu = { git = "https://github.com/parker-andrew-forks/wgpu-bridge.git", rev="72e0dfdec4aa75adfcd4383be4dcffafa26eaff8"}
+lamco-wgpu = { git = "https://github.com/parker-andrew-forks/wgpu-bridge.git", rev="6159eaf26e9a1a0d78f45d843f90d361706c9620"}
 open = "5.3.2"
 rand = {version="0.9"}
 detect-desktop-environment = "1.2.0"

--- a/flatpak/fracture.metainfo.xml
+++ b/flatpak/fracture.metainfo.xml
@@ -38,6 +38,11 @@
     </p>
   </description>
   <releases>
+    <release type="stable" version="0.0.6" date="2026-05-22T00:00:00Z">
+      <description>
+        <p>crosshair selection, improved device support, and improved stability</p>
+      </description>
+    </release>
     <release type="stable" version="0.0.5" date="2026-05-18T00:00:00Z">
       <description>
         <p>choose present mode and issues resolved</p>

--- a/src/global_application_state.rs
+++ b/src/global_application_state.rs
@@ -12,7 +12,7 @@ pub static FRAME_TRANSFER: LazyLock<Mutex<Option<Arc<LastReported>>>> =
 
 pub const SAFE_MODE: &'static str = "SAFE_MODE";
 
-pub const VERSION: &'static str = "0.0.5";
+pub const VERSION: &'static str = "0.0.6";
 
 pub static FOUND_VERSION: LazyLock<String> = LazyLock::new(|| {
     if let Ok(v) = reqwest::blocking::get("https://fracture.systems/fracture/VERSION") {

--- a/src/gpu_mirror_display/utility_texture.rs
+++ b/src/gpu_mirror_display/utility_texture.rs
@@ -193,7 +193,13 @@ pub(crate) fn position_image<'a, 'b>(
 
     let data = match &overlay.data {
         DmaOrCpuMemory::Dma => DmaOrCpuMemory::Dma,
-        DmaOrCpuMemory::Cpu(items) => DmaOrCpuMemory::Cpu(&items[skip_rows * bytes_per_row..]),
+        DmaOrCpuMemory::Cpu(items) => {
+            // it might not be that the math is wrong, but the window size shouldn't be
+            // checked while rendering to an exact surface size. (if the window size
+            // is reported as changing, and rendering is based on the window size,
+            // then it's possible to render more than the surface size which is an error)
+            DmaOrCpuMemory::Cpu(&items[(skip_rows * bytes_per_row).min(items.len() - 1)..])
+        }
     };
 
     let temp = PositioningData {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,18 @@ fn main() {
         }
     }
 
+    // I think Vulkan might be unstable for GTK, so I'm disabling it to see if it improves stability.
+    //
+    // "Currently, the GTK Vulkan backend doesn't do any error handling.
+    //  Every error is considered fatal. So it's expected that it crashes."
+    //
+    // https://gitlab.gnome.org/GNOME/gtk/-/work_items/7909
+    {
+        unsafe {
+            env::set_var("GDK_DISABLE", "vulkan");
+        }
+    }
+
     let (gpu, ui, dbus) = ApplicationChannelsCreator::channels();
     let (send_init_complete, init_complete) = std::sync::mpsc::channel::<()>();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,11 @@ fn main() {
     {
         unsafe {
             env::set_var("GDK_DISABLE", "vulkan");
+
+            // I'm just going to set the renderer to software based cairo because
+            // it seems even more stable, and that's all I care about for GTK. I'm
+            // not using GTK to render anything, it doesn't need to be complicated.
+            env::set_var("GSK_RENDERER", "cairo");
         }
     }
 

--- a/src/shaders/ui.wgsl
+++ b/src/shaders/ui.wgsl
@@ -174,7 +174,9 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         }
         
         if u32(in.clip_position.x) >= u32(sub_x) && u32(in.clip_position.x) <= max_x + 5 && u32(in.clip_position.y) >= u32(sub_y) && u32(in.clip_position.y) <= max_y + 5 {
-            color = cut_color;
+            var mirror = textureSample(t_diffuse, s_diffuse, in.tex_coords);
+
+            color = vec4(1.0 - mirror.r, 1.0 - mirror.g, 1.0 - mirror.b, 1.0);
 
             in_cut_region = true;
         }

--- a/src/shaders/ui.wgsl
+++ b/src/shaders/ui.wgsl
@@ -256,6 +256,39 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
 
     if (flags.flagged & WaitingForCrop) != 0 && !in_cut_region {
+   
+            let x = in.tex_coords.x;
+            let y = in.tex_coords.y;
+
+            let zx = u32(f32(flags.surface_width) * x);
+            let zy = u32(f32(flags.surface_height) * y);
+
+            if (zx == flags.mouse_x || zy == flags.mouse_y) && (flags.flagged & MouseDown) == 0  {
+
+                var mirror = textureSample(t_diffuse, s_diffuse, in.tex_coords);
+
+                var m_red = 1.0;
+                var m_green = 1.0;
+                var m_blue = 1.0;
+
+                if mirror.r > 0.5 {
+                    m_red = 0.0;
+                }
+                
+                if mirror.b > 0.5 {
+                    m_blue = 0.0;
+                }
+                
+                if mirror.g > 0.5 {
+                    m_green = 0.0;
+                }
+
+
+                color = vec4(m_red, m_green, m_blue, 1.0);
+            }
+
+
+
         var color2: vec4<f32> = textureSample(overlay, s_diffuse, in.tex_coords);
 
         if color2.r != 0.0 || color2.g != 0.0 || color2.b != 0.0 {

--- a/src/shaders/ui.wgsl
+++ b/src/shaders/ui.wgsl
@@ -191,7 +191,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
                 m_green = 0.0;
             }
 
-            color = vec4(m_red, m_blue, m_green, 1.0);
+            color = vec4(m_red, m_green, m_blue, 1.0);
 
             in_cut_region = true;
         }

--- a/src/shaders/ui.wgsl
+++ b/src/shaders/ui.wgsl
@@ -67,7 +67,6 @@ var<uniform> flags: UiRenderData;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    var cut_color = vec4(1.0, 1.0, 1.0, 1.0);
     var color = vec4(0.0, 0.0, 0.0, 0.0);
 
     color.a = color.a - (1.0 - flags.transparency);
@@ -176,7 +175,23 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         if u32(in.clip_position.x) >= u32(sub_x) && u32(in.clip_position.x) <= max_x + 5 && u32(in.clip_position.y) >= u32(sub_y) && u32(in.clip_position.y) <= max_y + 5 {
             var mirror = textureSample(t_diffuse, s_diffuse, in.tex_coords);
 
-            color = vec4(1.0 - mirror.r, 1.0 - mirror.g, 1.0 - mirror.b, 1.0);
+            var m_red = 1.0;
+            var m_green = 1.0;
+            var m_blue = 1.0;
+
+            if mirror.r > 0.5 {
+                m_red = 0.0;
+            }
+            
+            if mirror.b > 0.5 {
+                m_blue = 0.0;
+            }
+            
+            if mirror.g > 0.5 {
+                m_green = 0.0;
+            }
+
+            color = vec4(m_red, m_blue, m_green, 1.0);
 
             in_cut_region = true;
         }

--- a/src/stream_creation/start_mirror_stream.rs
+++ b/src/stream_creation/start_mirror_stream.rs
@@ -394,6 +394,65 @@ pub fn start_mirroring(
 
     let run_scan_meta = run_frame_scan.clone();
 
+    let without_dma_modifiers = pipewire::spa::pod::Object {
+        type_: (pw::spa::utils::SpaTypes::ObjectParamFormat).as_raw(),
+        id: (pw::spa::param::ParamType::EnumFormat).as_raw(),
+        properties: [
+            (pipewire::spa::pod::Property {
+                key: (pw::spa::param::format::FormatProperties::MediaType).as_raw(),
+                flags: pipewire::spa::pod::PropertyFlags::empty(),
+                value: (pipewire::spa::pod::Value::Id(pipewire::spa::utils::Id(
+                    (pw::spa::param::format::MediaType::Video).as_raw(),
+                ))),
+            }),
+            (pipewire::spa::pod::Property {
+                key: (pw::spa::param::format::FormatProperties::MediaSubtype).as_raw(),
+                flags: pipewire::spa::pod::PropertyFlags::empty(),
+                value: (pipewire::spa::pod::Value::Id(pipewire::spa::utils::Id(
+                    (pw::spa::param::format::MediaSubtype::Raw).as_raw(),
+                ))),
+            }),
+            (pipewire::spa::pod::Property {
+                key: (pw::spa::param::format::FormatProperties::VideoFormat).as_raw(),
+                flags: pipewire::spa::pod::PropertyFlags::empty(),
+                value: (pipewire::spa::pod::Value::Choice(pipewire::spa::pod::ChoiceValue::Id(
+                    pipewire::spa::utils::Choice::<pipewire::spa::utils::Id>(
+                        pipewire::spa::utils::ChoiceFlags::empty(),
+                        pipewire::spa::utils::ChoiceEnum::Enum {
+                            default: pipewire::spa::utils::Id(
+                                (pw::spa::param::video::VideoFormat::BGRA).as_raw(),
+                            ),
+                            alternatives: [
+                                pipewire::spa::utils::Id(
+                                    (pw::spa::param::video::VideoFormat::BGRA).as_raw(),
+                                ),
+                                pipewire::spa::utils::Id(
+                                    (pw::spa::param::video::VideoFormat::RGBA).as_raw(),
+                                ),
+                                pipewire::spa::utils::Id(
+                                    (pw::spa::param::video::VideoFormat::RGB).as_raw(),
+                                ),
+                                pipewire::spa::utils::Id(
+                                    (pw::spa::param::video::VideoFormat::RGBA).as_raw(),
+                                ),
+                                pipewire::spa::utils::Id(
+                                    (pw::spa::param::video::VideoFormat::RGBx).as_raw(),
+                                ),
+                                pipewire::spa::utils::Id(
+                                    (pw::spa::param::video::VideoFormat::BGRx).as_raw(),
+                                ),
+                            ]
+                            .to_vec(),
+                        },
+                    ),
+                ))),
+            }),
+        ]
+        .to_vec(),
+    };
+
+    let state_change_pod_values = without_dma_modifiers.clone();
+
     let _listener = stream
         .add_local_listener_with_user_data(meta)
         .add_buffer(|_, _, pw| unsafe {
@@ -414,7 +473,39 @@ pub fn start_mirroring(
 
             let _ = remove_buffer_copy.lock().unwrap().remove(&buff_fd);
         })
-        .state_changed(|_, _, old, new| {
+        .state_changed(move |stream_ref, _, old, new| {
+            match stream_ref.state() {
+                v @ pipewire::stream::StreamState::Error(_) => {
+                    println!("{:#?}", v);
+
+                    println!("Attempting to downgrade DmaBuffers to CpuBuffers");
+
+                    // For now I'm just going to assume that errors are related
+                    // to not finding a way to negotiate the stream. The only
+                    // option available at the moment is to downgrade the stream
+                    // from DmaBuffers to CpuBuffers.
+                    //
+                    // I don't think errors should ever close the application. The user
+                    // might be running shaders that they want have continue running after
+                    // the stream ends.
+
+                    let temp = state_change_pod_values.clone();
+
+                    let temp: Vec<u8> = pw::spa::pod::serialize::PodSerializer::serialize(
+                        std::io::Cursor::new(Vec::new()),
+                        &pw::spa::pod::Value::Object(temp),
+                    )
+                    .unwrap()
+                    .0
+                    .into_inner();
+
+                    let mut parameters = [spa::pod::Pod::from_bytes(&temp).unwrap()];
+
+                    let _ = stream_ref.update_params(&mut parameters);
+                }
+                _ => {}
+            }
+
             println!("State changed: {:?} -> {:?}", old, new);
         })
         .param_changed(move |_, meta, id, param| {
@@ -825,62 +916,7 @@ pub fn start_mirroring(
         }
     };
 
-    let mut obj = pipewire::spa::pod::Object {
-        type_: (pw::spa::utils::SpaTypes::ObjectParamFormat).as_raw(),
-        id: (pw::spa::param::ParamType::EnumFormat).as_raw(),
-        properties: [
-            (pipewire::spa::pod::Property {
-                key: (pw::spa::param::format::FormatProperties::MediaType).as_raw(),
-                flags: pipewire::spa::pod::PropertyFlags::empty(),
-                value: (pipewire::spa::pod::Value::Id(pipewire::spa::utils::Id(
-                    (pw::spa::param::format::MediaType::Video).as_raw(),
-                ))),
-            }),
-            (pipewire::spa::pod::Property {
-                key: (pw::spa::param::format::FormatProperties::MediaSubtype).as_raw(),
-                flags: pipewire::spa::pod::PropertyFlags::empty(),
-                value: (pipewire::spa::pod::Value::Id(pipewire::spa::utils::Id(
-                    (pw::spa::param::format::MediaSubtype::Raw).as_raw(),
-                ))),
-            }),
-            (pipewire::spa::pod::Property {
-                key: (pw::spa::param::format::FormatProperties::VideoFormat).as_raw(),
-                flags: pipewire::spa::pod::PropertyFlags::empty(),
-                value: (pipewire::spa::pod::Value::Choice(pipewire::spa::pod::ChoiceValue::Id(
-                    pipewire::spa::utils::Choice::<pipewire::spa::utils::Id>(
-                        pipewire::spa::utils::ChoiceFlags::empty(),
-                        pipewire::spa::utils::ChoiceEnum::Enum {
-                            default: pipewire::spa::utils::Id(
-                                (pw::spa::param::video::VideoFormat::BGRA).as_raw(),
-                            ),
-                            alternatives: [
-                                pipewire::spa::utils::Id(
-                                    (pw::spa::param::video::VideoFormat::BGRA).as_raw(),
-                                ),
-                                pipewire::spa::utils::Id(
-                                    (pw::spa::param::video::VideoFormat::RGBA).as_raw(),
-                                ),
-                                pipewire::spa::utils::Id(
-                                    (pw::spa::param::video::VideoFormat::RGB).as_raw(),
-                                ),
-                                pipewire::spa::utils::Id(
-                                    (pw::spa::param::video::VideoFormat::RGBA).as_raw(),
-                                ),
-                                pipewire::spa::utils::Id(
-                                    (pw::spa::param::video::VideoFormat::RGBx).as_raw(),
-                                ),
-                                pipewire::spa::utils::Id(
-                                    (pw::spa::param::video::VideoFormat::BGRx).as_raw(),
-                                ),
-                            ]
-                            .to_vec(),
-                        },
-                    ),
-                ))),
-            }),
-        ]
-        .to_vec(),
-    };
+    let mut obj = without_dma_modifiers.clone();
 
     if let Some(mods) = mods {
         println!("DmaBuffer modifiers are specified.");

--- a/src/stream_creation/start_mirror_stream.rs
+++ b/src/stream_creation/start_mirror_stream.rs
@@ -793,7 +793,12 @@ pub fn start_mirroring(
 
                 let mods: Vec<_> = v
                     .iter()
-                    .map(|v| v.modifiers.iter().map(|v| *v as i64))
+                    .map(|v| {
+                        v.modifier_props
+                            .iter()
+                            .filter(|prop| prop.plane_count == 1)
+                            .map(|m| m.modifier as i64)
+                    })
                     .flatten()
                     .collect();
 

--- a/src/stream_creation/start_mirror_stream.rs
+++ b/src/stream_creation/start_mirror_stream.rs
@@ -14,10 +14,7 @@ use crate::{
 };
 use drm_fourcc::DrmFourcc;
 use gnome_window_calls::abstraction::{Window, WindowCache};
-use lamco_wgpu::{
-    bridge::SupportedDmaBufImport,
-    smithay_reexports::{self, Dmabuf},
-};
+use lamco_wgpu::smithay_reexports::{self, Dmabuf};
 use mmap::MapOption;
 use pipewire::{
     self as pw,
@@ -796,14 +793,7 @@ pub fn start_mirroring(
 
                 let mods: Vec<_> = v
                     .iter()
-                    .map(|v| {
-                        v.modifiers.iter().map(|v| *v as i64).filter(|modifier| {
-                            v.image_create_mods.contains(&SupportedDmaBufImport {
-                                modifier: *modifier as u64,
-                                vk_format: v.vk_format,
-                            })
-                        })
-                    })
+                    .map(|v| v.modifiers.iter().map(|v| *v as i64))
                     .flatten()
                     .collect();
 

--- a/src/stream_creation/start_mirror_stream.rs
+++ b/src/stream_creation/start_mirror_stream.rs
@@ -14,7 +14,10 @@ use crate::{
 };
 use drm_fourcc::DrmFourcc;
 use gnome_window_calls::abstraction::{Window, WindowCache};
-use lamco_wgpu::smithay_reexports::{self, Dmabuf};
+use lamco_wgpu::{
+    bridge::SupportedDmaBufImport,
+    smithay_reexports::{self, Dmabuf},
+};
 use mmap::MapOption;
 use pipewire::{
     self as pw,
@@ -793,7 +796,14 @@ pub fn start_mirroring(
 
                 let mods: Vec<_> = v
                     .iter()
-                    .map(|v| v.modifiers.iter().map(|v| *v as i64))
+                    .map(|v| {
+                        v.modifiers.iter().map(|v| *v as i64).filter(|modifier| {
+                            v.image_create_mods.contains(&SupportedDmaBufImport {
+                                modifier: *modifier as u64,
+                                vk_format: v.vk_format,
+                            })
+                        })
+                    })
                     .flatten()
                     .collect();
 


### PR DESCRIPTION
* DmaBuffers ignore multiplane formats. It improves device support. With the 7.0 Linux Kernel, I noticed that my laptop started failing to use DmaBuffers. DmaBuffers are very important for performance
* Gtk uses cairo now. This seems so much more stable than Vulkan, I haven't crashed using GTK since switching
* Added a crosshair selection
* Downgrade from DmaBuffers is pipewire reaches an error state where it isn't doing anything.
* Temporarily patch an indexing error